### PR TITLE
fix: close toltip from inside title content

### DIFF
--- a/src/components/atoms/Modal.tsx
+++ b/src/components/atoms/Modal.tsx
@@ -33,6 +33,7 @@ export default function Modal({
   onClose,
 }: ModalProps) {
   const [open, setOpen] = useStateWithProp(isOpen);
+
   const handleOpenChange = useCallback(
     (value: boolean) => {
       setOpen(value);

--- a/src/components/atoms/Tooltip.stories.tsx
+++ b/src/components/atoms/Tooltip.stories.tsx
@@ -1,5 +1,6 @@
 import { Placement } from "@floating-ui/react";
 import { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
 
 import { playFloatingBasic } from "../../tools/storybook/play.js";
 import Tooltip, { TooltipProps } from "./Tooltip.js";
@@ -179,4 +180,37 @@ export const Triggers: Story = {
       </div>
     </div>
   ),
+};
+
+const WithButton = () => {
+  const [open, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <Tooltip
+        isOpen={open}
+        onClick={() => {
+          setIsOpen(true);
+        }}
+        onClose={() => setIsOpen(false)}
+        title={
+          <div>
+            Content in Tooltip!
+            <button
+              onClick={() => setIsOpen(false)}
+              style={{ marginLeft: "auto" }}
+            >
+              Close
+            </button>
+          </div>
+        }
+      >
+        Content in Tooltip!
+      </Tooltip>
+    </>
+  );
+};
+
+export const withButton: Story = {
+  render: () => <WithButton />,
 };

--- a/src/components/atoms/Tooltip.tsx
+++ b/src/components/atoms/Tooltip.tsx
@@ -21,6 +21,7 @@ import {
 import { clsx } from "clsx";
 import {
   CSSProperties,
+  MouseEventHandler,
   ReactNode,
   RefObject,
   cloneElement,
@@ -48,6 +49,8 @@ export interface TooltipProps {
   };
   isOpen?: boolean;
   isPopover?: boolean;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  onClose?: () => void;
   options?: {
     offset?: OffsetOptions;
     padding?: Padding;
@@ -68,6 +71,8 @@ export default function Tooltip({
   innerClassNames = {},
   isOpen,
   isPopover,
+  onClick,
+  onClose,
   options: propsOptions,
   placement,
   portal,
@@ -79,6 +84,14 @@ export default function Tooltip({
   const arrowRef = useRef<HTMLElement>(null);
   const [open, setOpen] = useStateWithProp(isOpen);
   const options = { ...defaultOptions, ...propsOptions };
+
+  console.log({ isOpen, open });
+
+  const handleOpenChange = (value: boolean) => {
+    setOpen(value);
+    onClose?.();
+  };
+
   const { context, floatingStyles, middlewareData, refs } = useFloating({
     middleware: [
       ...(placement ? [] : [autoPlacement()]),
@@ -86,7 +99,7 @@ export default function Tooltip({
       shift({ padding: options.padding }),
       ...(showArrow ? [arrow({ element: arrowRef.current })] : []),
     ],
-    onOpenChange: setOpen,
+    onOpenChange: handleOpenChange,
     open,
     ...(placement ? { placement } : {}),
     whileElementsMounted: autoUpdate,
@@ -166,7 +179,10 @@ export default function Tooltip({
       <button
         className={clsx(styles.reference, innerClassNames.reference)}
         style={style}
-        {...getReferenceProps({ ref: refs.setReference })}
+        {...getReferenceProps({
+          onClick,
+          ref: refs.setReference,
+        })}
       >
         {children}
       </button>
@@ -175,6 +191,7 @@ export default function Tooltip({
     children,
     getReferenceProps,
     innerClassNames.reference,
+    onClick,
     refs.setReference,
     style,
   ]);

--- a/src/hooks/useStateWithProp.ts
+++ b/src/hooks/useStateWithProp.ts
@@ -1,11 +1,14 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useUpdateEffect } from "react-use";
 
 export default function useStateWithProp<TState>(
   value: TState,
 ): [TState, React.Dispatch<React.SetStateAction<TState>>] {
   const [state, setState] = useState<TState>(value);
-  useEffect(() => {
+
+  useUpdateEffect(() => {
     if (value !== undefined) setState(value);
   }, [value]);
+
   return [state, setState];
 }


### PR DESCRIPTION
Earlier we were not able to maintain correct value in the isOpen/open state in the parent of the Tooltip/Popover component.