### PR TITLE
fix: remove redundant isOpen state in modal

### DIFF
--- a/src/components/atoms/Modal.stories.tsx
+++ b/src/components/atoms/Modal.stories.tsx
@@ -1,22 +1,30 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useState } from "react";
 
 import { playFloatingBasic } from "../../tools/storybook/play.js";
 import Modal, { ModalProps } from "./Modal.js";
 
-const Template = ({ isOpen = false, modalContent = "", ...args }) => {
-  const [open, setOpen] = useState(isOpen);
-
-  useEffect(() => {
-    setOpen(isOpen);
-  }, [isOpen]);
-
+const Template = ({
+  initiallyOpen,
+  modalContent = "",
+  onClose,
+  ...args
+}: ModalProps & { initiallyOpen?: boolean; modalContent?: ReactNode }) => {
+  const [open, setOpen] = useState<boolean>(!!initiallyOpen);
+  console.log(open);
   return (
     <div>
       <button id="showButton" onClick={() => setOpen(true)}>
         Show Modal
       </button>
-      <Modal isOpen={open} onClose={() => setOpen(false)} {...args}>
+      <Modal
+        isOpen={open}
+        onClose={() => {
+          setOpen(false);
+          onClose?.();
+        }}
+        {...args}
+      >
         <div className="story-box">{modalContent || MODAL_TEXT}</div>
       </Modal>
     </div>

--- a/src/components/atoms/Modal.tsx
+++ b/src/components/atoms/Modal.tsx
@@ -12,7 +12,6 @@ import {
 import { clsx } from "clsx";
 import { ReactNode } from "react";
 
-import useStateWithProp from "../../hooks/useStateWithProp.js";
 import styles from "./modal.module.css";
 
 export interface ModalProps {
@@ -32,16 +31,13 @@ export default function Modal({
   isOpen = false,
   onClose,
 }: ModalProps) {
-  const [open, setOpen] = useStateWithProp(isOpen);
-
   const handleOpenChange = (value: boolean) => {
-    setOpen(value);
     onClose?.();
   };
 
   const { context, refs } = useFloating({
     onOpenChange: handleOpenChange,
-    open,
+    open: isOpen,
   });
 
   const id = useId();
@@ -58,7 +54,7 @@ export default function Modal({
     <>
       <div {...getReferenceProps({ ref: refs.setReference })} />
       <FloatingPortal>
-        {open && (
+        {isOpen && (
           <FloatingOverlay
             className={clsx(styles.overlay, innerClassNames.overlay)}
             lockScroll


### PR DESCRIPTION
Remove inner open state from modal to avoid synchronisation problem with outer state.