### PR TITLE
fix: tooltip placement dynamic

### DIFF
--- a/src/components/atoms/Tooltip.tsx
+++ b/src/components/atoms/Tooltip.tsx
@@ -5,8 +5,8 @@ import {
   Padding,
   Placement,
   arrow,
-  autoPlacement,
   autoUpdate,
+  flip,
   offset,
   shift,
   useClick,
@@ -93,7 +93,7 @@ export default function Tooltip({
 
   const { context, floatingStyles, middlewareData, refs } = useFloating({
     middleware: [
-      ...(placement ? [] : [autoPlacement()]),
+      flip(),
       offset(options.offset),
       shift({ padding: options.padding }),
       ...(showArrow ? [arrow({ element: arrowRef.current })] : []),


### PR DESCRIPTION
Issue - The tooltip placement is no longer dynamic (i.e. remains same when space is not enough) when placement prop is given. 

The `autoPlacement` middleware uses the "most space" strategy. Which forces the tooltip/popover in undesired placement even when enough space is available at the desired place. 

`flip` on the other hand uses the "no space" strategy. This will only change the placement when enough space is not available in the preferred place. 

The difference b/w `flip` and `autoPlacement`: https://floating-ui.com/docs/autoplacement#conflict-with-flip