### PR TITLE
fix: tooltip valid element props and onClose

### DIFF
--- a/src/components/atoms/Tooltip.stories.tsx
+++ b/src/components/atoms/Tooltip.stories.tsx
@@ -216,30 +216,28 @@ export const WithButton: Story = {
 const ValidElementChildTemplate = (args: Partial<TooltipProps>) => {
   const [open, setIsOpen] = useState(false);
   const [tooltipCount, setTooltipCount] = useState(0);
-  const [buttonCount, setButtonCount] = useState(0);
+  const [inputFocusCount, setInputFocusCount] = useState(0);
 
   return (
     <>
-      <div>Tooltip clicked: {tooltipCount} times</div>
-      <div>Button clicked: {buttonCount} times</div>
+      <div>tooltip clicked: {tooltipCount} times</div>
+      <div>input focus count: {inputFocusCount} times</div>
       <Tooltip
         isOpen={open}
         onClick={() => {
           setTooltipCount((previous) => previous + 1);
-          setIsOpen(true);
         }}
         onClose={() => setIsOpen(false)}
         title={<div>Content in Tooltip!</div>}
         {...args}
       >
-        <button
-          onClick={() => {
-            setButtonCount((previous) => previous + 1);
+        <input
+          onFocus={() => {
+            setInputFocusCount((previous) => previous + 1);
             setIsOpen(true);
           }}
-        >
-          Content in Tooltip!
-        </button>
+          placeholder="Click for Tooltip!"
+        />
       </Tooltip>
     </>
   );

--- a/src/components/atoms/Tooltip.tsx
+++ b/src/components/atoms/Tooltip.tsx
@@ -87,7 +87,7 @@ export default function Tooltip({
 
   const handleOpenChange = (value: boolean) => {
     setInternalOpen(value);
-    onClose?.();
+    if (!value) onClose?.();
   };
 
   const options = { ...defaultOptions, ...propsOptions };
@@ -184,6 +184,7 @@ export default function Tooltip({
         ),
         style,
         ...getReferenceProps({
+          ...childProps,
           onClick: (event) => {
             childProps.onClick?.(event);
             onClick?.(event);


### PR DESCRIPTION
Props other than onClick were no propagated in the child element when cloning. Resulting in unexpected behavior.

Also, the onClose was triggered both on open = false and open = true, resulting in unexpected closing on the popover in some cases. 