### PR TITLE
🧹 Refactor to remove pseudo-random eslint disables

### DIFF
--- a/packages/js/src/tools/colors.ts
+++ b/packages/js/src/tools/colors.ts
@@ -60,10 +60,16 @@ export function hexToRgb(hex: string) {
 const RGB_BASE = 0xff_ff_ff;
 const MAX_RGB = 255;
 const MAX_ANGLE = 360;
+const UINT32_MAX = 0xff_ff_ff_ff;
+
+function getRandomValue() {
+  const array = new Uint32Array(1);
+  globalThis.crypto.getRandomValues(array);
+  return array[0] / UINT32_MAX;
+}
 
 function getRandomRgb(opacity = 100) {
-  // eslint-disable-next-line sonarjs/pseudo-random
-  const number_ = Math.round(RGB_BASE * Math.random());
+  const number_ = Math.round(RGB_BASE * getRandomValue());
   const r = number_ >> G_SHIFT;
   const g = (number_ >> B_SHIFT) & MAX_RGB;
   const b = number_ & MAX_RGB;
@@ -85,7 +91,6 @@ function getRandomRgb(opacity = 100) {
 export function randomGradientGenerator(opacity: number) {
   const newColor1 = getRandomRgb(opacity);
   const newColor2 = getRandomRgb(opacity);
-  // eslint-disable-next-line sonarjs/pseudo-random
-  const angle = Math.round(Math.random() * MAX_ANGLE);
+  const angle = Math.round(getRandomValue() * MAX_ANGLE);
   return `linear-gradient(${angle}deg, ${newColor1}, ${newColor2})`;
 }


### PR DESCRIPTION
The `eslint-disable-next-line sonarjs/pseudo-random` comments in `packages/js/src/tools/colors.ts` were used to suppress warnings about `Math.random()`. While the use case (random UI colors/gradients) isn't security-critical, it is better practice to use the cryptographically secure `crypto.getRandomValues()` to satisfy linter rules and improve overall code robustness.

This change:
1.  Introduces a `getRandomValue()` helper function using `globalThis.crypto.getRandomValues()`.
2.  Replaces all `Math.random()` calls in the file with this helper.
3.  Removes the now unnecessary ESLint disable comments.

The functionality of generating random colors and gradients remains unchanged. Verification was performed by manually reviewing the code changes and confirming the removal of the targeted ESLint disables. Comprehensive automated testing was hindered by environment issues but the code logic was verified through a code review process.

---
*PR created automatically by Jules for task [4255491510956624712](https://jules.google.com/task/4255491510956624712) started by @tiwariav*